### PR TITLE
Fixed DIO0 pin number

### DIFF
--- a/lora32u4-sketch/lora32u4-sketch.ino
+++ b/lora32u4-sketch/lora32u4-sketch.ino
@@ -58,9 +58,9 @@
     #define DIO2 LMIC_UNUSED_PIN
     #define RESET_PIN  1
 #elif LoRa32u4II_VERSION == LoRa32u4II_1_2
-    #define DIO0 0
+    #define DIO0 7
     #define DIO1 1
-    #define DIO2 2
+    #define DIO2 LMIC_UNUSED_PIN
     #define RESET_PIN 4
 #else
     #define DIO0 0


### PR DESCRIPTION
Pin number for DIO0 seemed to be incorrect, I use 7 instead of 0.

With DIO0 0 nothing happens after 'Starting', with DIO 7 once a package is send and received before the deep sleep kills the terminal connection.